### PR TITLE
Husky para pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+docker exec menu-calculator-app-1 npm run lint:fix
+docker exec menu-calculator-app-1 npm run format

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "@eslint/markdown": "^6.5.0",
                 "eslint": "^9.29.0",
                 "globals": "^16.2.0",
+                "husky": "^9.1.7",
                 "prettier": "^3.5.3"
             }
         },
@@ -1273,6 +1274,22 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/husky": {
+            "version": "9.1.7",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "husky": "bin.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/typicode"
             }
         },
         "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "dev": "pm2-dev ./bin/www",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
-        "format": "prettier --write ."
+        "format": "prettier --write .",
+        "prepare": "husky"
     },
     "dependencies": {
         "cookie-parser": "~1.4.4",
@@ -25,6 +26,7 @@
         "@eslint/markdown": "^6.5.0",
         "eslint": "^9.29.0",
         "globals": "^16.2.0",
+        "husky": "^9.1.7",
         "prettier": "^3.5.3"
     }
 }


### PR DESCRIPTION
# Descrição
Este PR introduz o Husky ao projeto para executar pre-commit hooks, como lint e formatação automática, garantindo qualidade de código antes dos commits.

## Observações importantes
Devido ao uso de containers Docker, onde os node_modules e scripts do Husky residem, o comportamento padrão do Husky não é aplicado automaticamente no host.
Para que os hooks funcionem corretamente, é necessário rodar o seguinte comando no ambiente do host (fora do container):

```bash
npx husky install

```
Esse comando configura o caminho dos hooks no Git, inserindo a diretiva abaixo no arquivo `.git/config`:

```bash
[core]
  hooksPath = .husky
```
Sem isso, os pre-commits não serão executados.